### PR TITLE
Implementation of Autoscaling Policy Sync

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,6 +58,24 @@
   version = "v1.15.79"
 
 [[projects]]
+  digest = "1:bf86c0cab4c6fde3f794ce91a5d7011ddf8a819a93bb3b56f1e4f23a1c867e7f"
+  name = "github.com/containership/cerebral"
+  packages = [
+    "pkg/apis/cerebral.containership.io",
+    "pkg/apis/cerebral.containership.io/v1alpha1",
+    "pkg/client/clientset/versioned",
+    "pkg/client/clientset/versioned/scheme",
+    "pkg/client/clientset/versioned/typed/cerebral.containership.io/v1alpha1",
+    "pkg/client/informers/externalversions",
+    "pkg/client/informers/externalversions/cerebral.containership.io",
+    "pkg/client/informers/externalversions/cerebral.containership.io/v1alpha1",
+    "pkg/client/informers/externalversions/internalinterfaces",
+    "pkg/client/listers/cerebral.containership.io/v1alpha1",
+  ]
+  pruneopts = "T"
+  revision = "7f872b1f0a3de48961a1e7aedbc6d7e629a69a27"
+
+[[projects]]
   digest = "1:9f42202ac457c462ad8bb9642806d275af9ab4850cf0b1960b9c6f083d4a309a"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -543,7 +561,7 @@
   revision = "46ad728b8d13de6dffe4396623b098473f626e9e"
 
 [[projects]]
-  digest = "1:c3024cff1dc2bbc3721c356abd9c20a21f54dfef47b898eb920bfc706d86b011"
+  digest = "1:3d0ba42a7eaed76c293905ced94201752762c84481f76505ac2079e6f332ae2b"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -553,11 +571,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "T"
-  revision = "1748dfb29e8a4432b78514bc88a1b07937a9805a"
-  version = "kubernetes-1.12.0"
+  revision = "0cd23ebeb6882bd1cdc2cb15fc7b2d72e8a86a5b"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
-  digest = "1:3818bcfa7e8b205b4425bce9fa6fb70a1f88e16e5519f17b45470faed1aae94e"
+  digest = "1:bcf693d144a1d98dabdb4ab3bf18fbde8b2f7ee86d2fd8a3f74fb6a035627550"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -604,11 +622,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
-  revision = "6dd46049f39503a1fc8d65de4bd566829e95faff"
-  version = "kubernetes-1.12.0"
+  revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
-  digest = "1:d6b3b22d9442b9c22e1b2cfe911e2f74e8aefb6fddae613769fea0de3e295374"
+  digest = "1:5aa94390c366adc57a82b19ad4f99482ab8fbeca0a2ff7b09db12d7baf590e46"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -778,8 +796,8 @@
     "util/workqueue",
   ]
   pruneopts = "T"
-  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
-  version = "v9.0.0"
+  revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
+  version = "kubernetes-1.12.3"
 
 [[projects]]
   branch = "release-1.10"
@@ -862,6 +880,11 @@
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ecr",
+    "github.com/containership/cerebral/pkg/apis/cerebral.containership.io/v1alpha1",
+    "github.com/containership/cerebral/pkg/client/clientset/versioned",
+    "github.com/containership/cerebral/pkg/client/clientset/versioned/scheme",
+    "github.com/containership/cerebral/pkg/client/informers/externalversions",
+    "github.com/containership/cerebral/pkg/client/listers/cerebral.containership.io/v1alpha1",
     "github.com/davecgh/go-spew/spew",
     "github.com/dgrijalva/jwt-go",
     "github.com/fsnotify/fsnotify",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,15 +50,19 @@ required = [
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.12.0"
+  version = "kubernetes-1.12.3"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.12.0"
+  version = "kubernetes-1.12.3"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "v9.0.0"
+  version = "kubernetes-1.12.3"
+
+[[constraint]]
+  name = "github.com/containership/cerebral"
+  revision = "7f872b1f0a3de48961a1e7aedbc6d7e629a69a27"
 
 [prune]
   go-tests = true

--- a/pkg/k8sutil/cerebral.go
+++ b/pkg/k8sutil/cerebral.go
@@ -1,0 +1,46 @@
+package k8sutil
+
+import (
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	cerebralclientset "github.com/containership/cerebral/pkg/client/clientset/versioned"
+	cerebralinformers "github.com/containership/cerebral/pkg/client/informers/externalversions"
+)
+
+// CerebralKubeAPI is an object for interacting with the CRDs cerebral
+// is using to extend kubernetes base api
+type CerebralKubeAPI struct {
+	client *cerebralclientset.Clientset
+	config *rest.Config
+}
+
+var cerebralAPI *CerebralKubeAPI
+
+func newCerebralClient(config *rest.Config) (*cerebralclientset.Clientset, error) {
+	return cerebralclientset.NewForConfig(config)
+}
+
+// CerebralAPI returns the instance of CerebralKubeAPI
+func CerebralAPI() *CerebralKubeAPI {
+	return cerebralAPI
+}
+
+// NewCerebralSharedInformerFactory returns a shared informer factory for
+// listening to and interacting with containership CRDs
+func (k CerebralKubeAPI) NewCerebralSharedInformerFactory(t time.Duration) cerebralinformers.SharedInformerFactory {
+	return cerebralinformers.NewSharedInformerFactory(k.client, t)
+}
+
+// Client returns the clientset which is what is used for getting the different
+// CRDs that containership has defined
+func (k CerebralKubeAPI) Client() *cerebralclientset.Clientset {
+	return k.client
+}
+
+// Config returns the configuration that was used for connecting to
+// kubernetes api
+func (k CerebralKubeAPI) Config() *rest.Config {
+	return k.config
+}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -52,9 +52,15 @@ func Initialize() error {
 		return errors.Wrap(err, "create Kubernetes extensions clientset failed")
 	}
 
+	cerebralclientset, err := newCerebralClient(config)
+	if err != nil {
+		return errors.Wrap(err, "create Kubernetes cerebral clientset failed")
+	}
+
 	kubeAPI = &KubeAPI{clientset, config}
 	csAPI = &CSKubeAPI{csclientset, config}
 	kubeExtensionsAPI = &KubeExtensionsAPI{extclientset, config}
+	cerebralAPI = &CerebralKubeAPI{cerebralclientset, config}
 
 	return nil
 }

--- a/pkg/resources/autoscaling_policy.go
+++ b/pkg/resources/autoscaling_policy.go
@@ -1,0 +1,151 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/containership/cluster-manager/pkg/request"
+
+	cerebralv1alpha1 "github.com/containership/cerebral/pkg/apis/cerebral.containership.io/v1alpha1"
+)
+
+// CsAutoscalingPolicies defines the Containership Cloud AutoscalingEngines resource
+type CsAutoscalingPolicies struct {
+	cloudResource
+	cache []cerebralv1alpha1.AutoscalingPolicy
+}
+
+// CloudAPIAutoscalingPolicy is the spec for a autoscaling group
+type CloudAPIAutoscalingPolicy struct {
+	ID                  string                `json:"id"`
+	MetricsBackend      string                `json:"metrics_backend"`
+	Metric              string                `json:"metric"`
+	MetricConfiguration map[string]string     `json:"metric_configuration"`
+	ScalingPolicy       CloudAPIScalingPolicy `json:"scaling_policy"`
+	PollInterval        int                   `json:"poll_interval"`
+	SamplePeriod        int                   `json:"sample_period"`
+}
+
+// CloudAPIScalingPolicy holds the policy configurations for scaling up and down
+type CloudAPIScalingPolicy struct {
+	ScaleUp   CloudAPIScalingPolicyConfiguration `json:"scale_up"`
+	ScaleDown CloudAPIScalingPolicyConfiguration `json:"scale_down"`
+}
+
+// A CloudAPIScalingPolicyConfiguration defines the criterion for triggering a scale event
+type CloudAPIScalingPolicyConfiguration struct {
+	Threshold          float64 `json:"threshold"`
+	ComparisonOperator string  `json:"comparison_operator"`
+	AdjustmentType     string  `json:"adjustment_type"`
+	AdjustmentValue    int     `json:"adjustment_value"`
+}
+
+// NewCsAutoscalingPolicies constructs a new CsAutoscalingPolicies
+func NewCsAutoscalingPolicies() *CsAutoscalingPolicies {
+	return &CsAutoscalingPolicies{
+		cloudResource: cloudResource{
+			endpoint: "/organizations/{{.OrganizationID}}/clusters/{{.ClusterID}}/autoscaling-policies",
+			service:  request.CloudServiceProvision,
+		},
+		cache: make([]cerebralv1alpha1.AutoscalingPolicy, 0),
+	}
+}
+
+// UnmarshalToCache take the json returned from containership api
+// and writes it to CsAutoscalingPolicies cache
+func (us *CsAutoscalingPolicies) UnmarshalToCache(bytes []byte) error {
+	cloudAutoscalingPolicies := make([]CloudAPIAutoscalingPolicy, 0)
+	err := json.Unmarshal(bytes, &cloudAutoscalingPolicies)
+	if err != nil {
+		return err
+	}
+
+	coerceCloudAPITypeToCerebral := make([]cerebralv1alpha1.AutoscalingPolicy, len(cloudAutoscalingPolicies))
+	for i, cap := range cloudAutoscalingPolicies {
+
+		// This converts the autoscaling policy object returned from the containership
+		// API into the Cerebral AutoscalingPolicy type. This object will then get written
+		// to the associated CR in camel case. In order to change to the Cerebral
+		// AutoscalingPolicy type you need to reference each value to convert, since
+		// the underlying types and structure is not consistent between the API representation
+		// of the object and the Cerebral representation of the object.
+		ae := cerebralv1alpha1.AutoscalingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cap.ID,
+			},
+			Spec: cerebralv1alpha1.AutoscalingPolicySpec{
+				MetricsBackend:      cap.MetricsBackend,
+				Metric:              cap.Metric,
+				MetricConfiguration: cap.MetricConfiguration,
+				PollInterval:        cap.PollInterval,
+				SamplePeriod:        cap.SamplePeriod,
+				ScalingPolicy: cerebralv1alpha1.ScalingPolicy{
+					ScaleUp: cerebralv1alpha1.ScalingPolicyConfiguration{
+						Threshold:          cap.ScalingPolicy.ScaleUp.Threshold,
+						ComparisonOperator: cap.ScalingPolicy.ScaleUp.ComparisonOperator,
+						AdjustmentType:     cap.ScalingPolicy.ScaleUp.AdjustmentType,
+						AdjustmentValue:    cap.ScalingPolicy.ScaleUp.AdjustmentValue,
+					},
+					ScaleDown: cerebralv1alpha1.ScalingPolicyConfiguration{
+						Threshold:          cap.ScalingPolicy.ScaleDown.Threshold,
+						ComparisonOperator: cap.ScalingPolicy.ScaleDown.ComparisonOperator,
+						AdjustmentType:     cap.ScalingPolicy.ScaleDown.AdjustmentType,
+						AdjustmentValue:    cap.ScalingPolicy.ScaleDown.AdjustmentValue,
+					},
+				},
+			},
+		}
+
+		coerceCloudAPITypeToCerebral[i] = ae
+	}
+
+	us.cache = coerceCloudAPITypeToCerebral
+
+	return nil
+}
+
+// Cache returns the autoscalingEngines cache
+func (us *CsAutoscalingPolicies) Cache() []cerebralv1alpha1.AutoscalingPolicy {
+	return us.cache
+}
+
+// IsEqual compares a AutoscalingEngineSpec to another AutoscalingEngine
+// new, cache
+func (us *CsAutoscalingPolicies) IsEqual(specObj interface{}, parentSpecObj interface{}) (bool, error) {
+	spec, ok := specObj.(cerebralv1alpha1.AutoscalingPolicySpec)
+	if !ok {
+		return false, fmt.Errorf("The object is not of type AutoscalingPolicySpec")
+	}
+
+	autoscalingPolicy, ok := parentSpecObj.(*cerebralv1alpha1.AutoscalingPolicy)
+	if !ok {
+		return false, fmt.Errorf("The object is not of type AutoscalingPolicy")
+	}
+
+	equal := autoscalingPolicy.Spec.MetricsBackend == spec.MetricsBackend &&
+		autoscalingPolicy.Spec.Metric == spec.Metric &&
+		autoscalingPolicy.Spec.PollInterval == spec.PollInterval &&
+		autoscalingPolicy.Spec.SamplePeriod == spec.SamplePeriod
+
+	if !equal {
+		return false, nil
+	}
+
+	equal = scalingPolicyIsEqual(spec.ScalingPolicy, autoscalingPolicy.Spec.ScalingPolicy)
+
+	return equal, nil
+}
+
+func scalingPolicyIsEqual(cloudPolicies, cachePolicies cerebralv1alpha1.ScalingPolicy) bool {
+	return scalingPolicyConfigurationIsEqual(cloudPolicies.ScaleUp, cachePolicies.ScaleUp) &&
+		scalingPolicyConfigurationIsEqual(cloudPolicies.ScaleDown, cachePolicies.ScaleDown)
+}
+
+func scalingPolicyConfigurationIsEqual(cloudPolicyConfiguration, cachePolicyConfiguration cerebralv1alpha1.ScalingPolicyConfiguration) bool {
+	return cloudPolicyConfiguration.Threshold == cachePolicyConfiguration.Threshold &&
+		cloudPolicyConfiguration.ComparisonOperator == cachePolicyConfiguration.ComparisonOperator &&
+		cloudPolicyConfiguration.AdjustmentType == cachePolicyConfiguration.AdjustmentType &&
+		cloudPolicyConfiguration.AdjustmentValue == cachePolicyConfiguration.AdjustmentValue
+}

--- a/pkg/resources/autoscaling_policy_test.go
+++ b/pkg/resources/autoscaling_policy_test.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cerebralv1alpha1 "github.com/containership/cerebral/pkg/apis/cerebral.containership.io/v1alpha1"
+)
+
+var autoscalingPolicyBytes = []byte(`[{
+	"name": "cpu-autoscaling-policy",
+	"policy": {
+		"scale_up": {
+			"threshold": 0.9,
+			"comparison_operator": ">=",
+			"adjustment_type": "absolute",
+			"adjustment_value": 1
+		},
+		"scale_down": {
+			"threshold": 0.3,
+			"comparison_operator": "<=",
+			"adjustment_type": "absolute",
+			"adjustment_value": 1
+		}
+	},
+	"metrics_backend": "035d5705-f8c8-4878-b7b5-0b3309e8d4e9",
+	"metric": "CPU",
+	"metric_configuration": {
+		"aggregation": "avg"
+	},
+	"poll_interval": 1234,
+	"sample_period": 3000
+}]`)
+
+var spc1 = cerebralv1alpha1.ScalingPolicyConfiguration{
+	Threshold:          0.8,
+	ComparisonOperator: ">",
+	AdjustmentType:     "absolute",
+	AdjustmentValue:    2,
+}
+
+var spc2 = cerebralv1alpha1.ScalingPolicyConfiguration{
+	Threshold:          0.8,
+	ComparisonOperator: ">",
+	AdjustmentType:     "absolute",
+	AdjustmentValue:    1,
+}
+
+func TestScalingPolicyConfigurationIsEqual(t *testing.T) {
+	result := scalingPolicyConfigurationIsEqual(spc1, spc1)
+	assert.True(t, result)
+
+	result = scalingPolicyConfigurationIsEqual(spc1, spc2)
+	assert.False(t, result)
+}
+
+var sp1 = cerebralv1alpha1.ScalingPolicy{
+	ScaleUp:   spc1,
+	ScaleDown: spc1,
+}
+
+var sp2 = cerebralv1alpha1.ScalingPolicy{
+	ScaleUp:   spc2,
+	ScaleDown: spc2,
+}
+
+func TestScalingPolicyIsEqual(t *testing.T) {
+	result := scalingPolicyIsEqual(sp1, sp1)
+	assert.True(t, result)
+
+	result = scalingPolicyIsEqual(sp1, sp2)
+	assert.False(t, result)
+}
+
+func TestUnmarshalToCache(t *testing.T) {
+	ap := NewCsAutoscalingPolicies()
+
+	err := ap.UnmarshalToCache(nil)
+	assert.Error(t, err)
+
+	err = ap.UnmarshalToCache(autoscalingPolicyBytes)
+	assert.Nil(t, err)
+}
+
+func TestAutoscalingGroupCache(t *testing.T) {
+	ap := NewCsAutoscalingPolicies()
+	ap.UnmarshalToCache(autoscalingPolicyBytes)
+	c := ap.Cache()
+
+	assert.Equal(t, ap.cache, c)
+
+	v, found := c[0].Spec.MetricConfiguration["aggregation"]
+	assert.True(t, found)
+	assert.Equal(t, "avg", v)
+}
+
+// Testing IsEqual function
+var cloud = cerebralv1alpha1.AutoscalingPolicySpec{
+	Metric: "CPU",
+}
+
+var cloudPolicyChange = cerebralv1alpha1.AutoscalingPolicySpec{
+	Metric:        "CPU",
+	ScalingPolicy: sp2,
+}
+
+var cloudChange = cerebralv1alpha1.AutoscalingPolicySpec{
+	Metric: "Memory",
+}
+
+var cacheObj = &cerebralv1alpha1.AutoscalingPolicy{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "asp1",
+	},
+	Spec: cerebralv1alpha1.AutoscalingPolicySpec{
+		Metric: "CPU",
+	},
+}
+
+func TestAutoscalingPolicyIsEqual(t *testing.T) {
+	ap := NewCsAutoscalingPolicies()
+
+	result, err := ap.IsEqual(cloud, cacheObj)
+	assert.Nil(t, err)
+	assert.True(t, result)
+
+	result, err = ap.IsEqual(cloudChange, cacheObj)
+	assert.Nil(t, err)
+	assert.False(t, result)
+
+	result, err = ap.IsEqual(cloudPolicyChange, cacheObj)
+	assert.Nil(t, err)
+	assert.False(t, result)
+
+	_, err = ap.IsEqual(cacheObj, cacheObj)
+	assert.Error(t, err)
+
+	_, err = ap.IsEqual(cloud, cloud)
+	assert.Error(t, err)
+}

--- a/pkg/resources/cloud_resource.go
+++ b/pkg/resources/cloud_resource.go
@@ -17,21 +17,28 @@ type CloudResource interface {
 	UnmarshalToCache(bytes []byte) error
 	// IsEqual compares a spec to it's parent object spec
 	IsEqual(spec interface{}, parentSpecObj interface{}) (bool, error)
+	// Service returns the request.CloudService type of the API to make a request to
+	Service() request.CloudService
 }
 
 // cloudResource defines what each resource needs to contain
 type cloudResource struct {
 	endpoint string
+	service  request.CloudService
 }
 
 func (cr cloudResource) Endpoint() string {
 	return cr.endpoint
 }
 
+func (cr cloudResource) Service() request.CloudService {
+	return cr.service
+}
+
 // Sync makes a request to cloud api for a resource and then writes the response
 // to the resources cache
 func Sync(cr CloudResource) error {
-	bytes, err := makeRequest(cr.Endpoint())
+	bytes, err := makeRequest(cr.Service(), cr.Endpoint())
 	if err != nil {
 		return err
 	}
@@ -43,8 +50,8 @@ func Sync(cr CloudResource) error {
 	return err
 }
 
-func makeRequest(endpoint string) ([]byte, error) {
-	req, err := request.New(request.CloudServiceAPI, endpoint, "GET", nil)
+func makeRequest(service request.CloudService, endpoint string) ([]byte, error) {
+	req, err := request.New(service, endpoint, "GET", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/cloud_resource_test.go
+++ b/pkg/resources/cloud_resource_test.go
@@ -1,0 +1,31 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/containership/cluster-manager/pkg/request"
+)
+
+func TestGetService(t *testing.T) {
+	service := request.CloudServiceAuth
+
+	cr := cloudResource{
+		endpoint: "",
+		service:  service,
+	}
+
+	assert.Equal(t, service, cr.Service())
+}
+
+func TestGetEndpoint(t *testing.T) {
+	endpoint := "/testing/endpoint"
+
+	cr := cloudResource{
+		endpoint: endpoint,
+		service:  request.CloudServiceProvision,
+	}
+
+	assert.Equal(t, endpoint, cr.Endpoint())
+}

--- a/pkg/resources/plugins.go
+++ b/pkg/resources/plugins.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containership/cluster-manager/pkg/request"
+
 	csv3 "github.com/containership/cluster-manager/pkg/apis/containership.io/v3"
 )
 
@@ -18,6 +20,7 @@ func NewCsPlugins() *CsPlugins {
 	return &CsPlugins{
 		cloudResource: cloudResource{
 			endpoint: "/organizations/{{.OrganizationID}}/clusters/{{.ClusterID}}/plugins",
+			service:  request.CloudServiceAPI,
 		},
 		cache: make([]csv3.PluginSpec, 0),
 	}

--- a/pkg/resources/registries.go
+++ b/pkg/resources/registries.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containership/cluster-manager/pkg/request"
 	"github.com/containership/cluster-manager/pkg/resources/registry"
 
 	csv3 "github.com/containership/cluster-manager/pkg/apis/containership.io/v3"
@@ -20,6 +21,7 @@ func NewCsRegistries() *CsRegistries {
 	return &CsRegistries{
 		cloudResource: cloudResource{
 			endpoint: "/organizations/{{.OrganizationID}}/registries",
+			service:  request.CloudServiceAPI,
 		},
 		cache: make([]csv3.RegistrySpec, 0),
 	}

--- a/pkg/resources/sync_controller/autoscaling_policy_sync_controller.go
+++ b/pkg/resources/sync_controller/autoscaling_policy_sync_controller.go
@@ -1,0 +1,161 @@
+package synccontroller
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	cerebralv1alpha1 "github.com/containership/cerebral/pkg/apis/cerebral.containership.io/v1alpha1"
+
+	cerebral "github.com/containership/cerebral/pkg/client/clientset/versioned"
+	cerebralinformers "github.com/containership/cerebral/pkg/client/informers/externalversions"
+	cerebrallisters "github.com/containership/cerebral/pkg/client/listers/cerebral.containership.io/v1alpha1"
+
+	"github.com/containership/cluster-manager/pkg/log"
+	"github.com/containership/cluster-manager/pkg/resources"
+	"github.com/containership/cluster-manager/pkg/tools"
+)
+
+// AutoscalingPolicySyncController is the implementation for syncing AutoscalingPolicy CRDs
+type AutoscalingPolicySyncController struct {
+	*syncController
+
+	cerebralclientset cerebral.Interface
+	cloudResource     *resources.CsAutoscalingPolicies
+	lister            cerebrallisters.AutoscalingPolicyLister
+}
+
+const (
+	autoscalingPolicySyncControllerName = "AutoscalingPolicySyncController"
+)
+
+// NewAutoscalingPolicyController returns a AutoscalingPolicySyncController that
+// will be in control of pulling from cloud comparing to the CR cache and
+// modifying based on those compares
+func NewAutoscalingPolicyController(kubeclientset kubernetes.Interface, clientset cerebral.Interface, cerebralInformerFactory cerebralinformers.SharedInformerFactory) *AutoscalingPolicySyncController {
+	autoscalingPolicyInformer := cerebralInformerFactory.Cerebral().V1alpha1().AutoscalingPolicies()
+
+	autoscalingPolicyInformer.Informer().AddIndexers(tools.IndexByIDKeyFun())
+
+	return &AutoscalingPolicySyncController{
+		syncController: &syncController{
+			name:     autoscalingPolicySyncControllerName,
+			synced:   autoscalingPolicyInformer.Informer().HasSynced,
+			informer: autoscalingPolicyInformer.Informer(),
+			recorder: tools.CreateAndStartRecorder(kubeclientset, autoscalingPolicySyncControllerName),
+		},
+
+		cerebralclientset: clientset,
+		lister:            autoscalingPolicyInformer.Lister(),
+		cloudResource:     resources.NewCsAutoscalingPolicies(),
+	}
+}
+
+// SyncWithCloud kicks of the Sync() function, should be started only after
+// Informer caches are synced
+func (c *AutoscalingPolicySyncController) SyncWithCloud(stopCh <-chan struct{}) error {
+	return c.syncWithCloud(c.doSync, stopCh)
+}
+
+func (c *AutoscalingPolicySyncController) doSync() {
+	log.Debug("Sync AutoscalingPolicies")
+	// makes a request to containership api and write results to the resource's cache
+	err := resources.Sync(c.cloudResource)
+	if err != nil {
+		log.Error("AutoscalingPolicies failed to sync: ", err.Error())
+		return
+	}
+
+	// write the cloud items by ID so we can easily see if anything needs
+	// to be deleted
+	cloudCacheByID := make(map[string]interface{}, 0)
+
+	for _, cloudItem := range c.cloudResource.Cache() {
+		cloudCacheByID[cloudItem.Name] = cloudItem
+
+		// Try to find cloud item in CR cache
+		item, err := c.informer.GetIndexer().ByIndex("byID", cloudItem.Name)
+		if err == nil && len(item) == 0 {
+			log.Debugf("Cloud AutoscalingPolicy %s does not exist as CR - creating", cloudItem.Name)
+			err = c.Create(cloudItem)
+			if err != nil {
+				log.Error("AutoscalingPolicy Create failed: ", err.Error())
+			}
+			continue
+		}
+
+		autoscalingPolicyCR := item[0]
+		if equal, err := c.cloudResource.IsEqual(cloudItem.Spec, autoscalingPolicyCR); err == nil && !equal {
+			log.Debugf("Cloud AutoscalingPolicy %s does not match CR - updating", cloudItem.Name)
+			err = c.Update(cloudItem, autoscalingPolicyCR)
+			if err != nil {
+				log.Error("AutoscalingPolicy Update failed: ", err.Error())
+			}
+			continue
+		}
+	}
+
+	allCRs, err := c.lister.List(labels.NewSelector())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	// Find CRs that do not exist in cloud
+	for _, ag := range allCRs {
+		if _, exists := cloudCacheByID[ag.Name]; !exists {
+			log.Debugf("CR AutoscalingPolicy %s does not exist in cloud - deleting", ag.Name)
+			err = c.Delete(ag.Name)
+			if err != nil {
+				log.Error("AutoscalingPolicy Delete failed: ", err.Error())
+			}
+		}
+	}
+}
+
+// Create takes a AutoscalingPolicy in cache and creates the CR
+func (c *AutoscalingPolicySyncController) Create(ag cerebralv1alpha1.AutoscalingPolicy) error {
+	autoscalingPolicy, err := c.cerebralclientset.Cerebral().AutoscalingPolicies().Create(&ag)
+	if err != nil {
+		return err
+	}
+
+	// We can only fire an event if the object was successfully created,
+	// otherwise there's no reasonable object to attach to.
+	c.recorder.Event(autoscalingPolicy, corev1.EventTypeNormal, "SyncCreate",
+		"Detected missing CR")
+
+	return nil
+}
+
+// Update takes an AutoscalingPolicy spec and updates the associated AutoscalingPolicy CR spec
+// with the new values
+func (c *AutoscalingPolicySyncController) Update(updatedAG cerebralv1alpha1.AutoscalingPolicy, obj interface{}) error {
+	autoscalingPolicy, ok := obj.(*cerebralv1alpha1.AutoscalingPolicy)
+	if !ok {
+		return fmt.Errorf("Error trying to use a non AutoscalingPolicy CR object to update a AutoscalingPolicy CR")
+	}
+
+	c.recorder.Event(autoscalingPolicy, corev1.EventTypeNormal, "AutoscalingPolicyUpdate",
+		"Detected change in Cloud, updating")
+
+	pCopy := autoscalingPolicy.DeepCopy()
+	pCopy.Spec = updatedAG.Spec
+
+	_, err := c.cerebralclientset.Cerebral().AutoscalingPolicies().Update(pCopy)
+
+	if err != nil {
+		c.recorder.Eventf(autoscalingPolicy, corev1.EventTypeWarning, "AutoscalingPolicyUpdateError",
+			"Error updating: %s", err.Error())
+	}
+
+	return err
+}
+
+// Delete takes a name or the CRD and deletes it
+func (c *AutoscalingPolicySyncController) Delete(name string) error {
+	return c.cerebralclientset.Cerebral().AutoscalingPolicies().Delete(name, &metav1.DeleteOptions{})
+}

--- a/pkg/resources/sync_controller/autoscaling_policy_sync_controller_test.go
+++ b/pkg/resources/sync_controller/autoscaling_policy_sync_controller_test.go
@@ -1,0 +1,29 @@
+package synccontroller
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	fakecerebral "github.com/containership/cerebral/pkg/client/clientset/versioned/fake"
+	cerebralinformers "github.com/containership/cerebral/pkg/client/informers/externalversions"
+	"github.com/stretchr/testify/assert"
+)
+
+func initalizeFakeAutoscalingPolicyController() *AutoscalingPolicySyncController {
+	client := &fake.Clientset{}
+	cerebralclient := fakecerebral.NewSimpleClientset()
+
+	cerebralInformerFactory := cerebralinformers.NewSharedInformerFactory(cerebralclient, 30*time.Second)
+	return NewAutoscalingPolicyController(client, cerebralclient, cerebralInformerFactory)
+}
+
+// NewAutoscalingPolicyController(kubeclientset kubernetes.Interface, clientset cerebral.Interface, cerebralInformerFactory cerebralinformers.SharedInformerFactory) *AutoscalingPolicySyncController
+func TestNewAutoscalingPolicyController(t *testing.T) {
+	apc := initalizeFakeAutoscalingPolicyController()
+
+	// test to make sure new creating a autoscaling controller is being
+	// created and returned
+	assert.Equal(t, autoscalingPolicySyncControllerName, apc.syncController.name)
+}

--- a/pkg/resources/users.go
+++ b/pkg/resources/users.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containership/cluster-manager/pkg/request"
+
 	csv3 "github.com/containership/cluster-manager/pkg/apis/containership.io/v3"
 )
 
@@ -18,6 +20,7 @@ func NewCsUsers() *CsUsers {
 	return &CsUsers{
 		cloudResource: cloudResource{
 			endpoint: "/organizations/{{.OrganizationID}}/users",
+			service:  request.CloudServiceAPI,
 		},
 		cache: make([]csv3.UserSpec, 0),
 	}


### PR DESCRIPTION
 ### Description

Adds in the Autoscaling Policy Sync controller, which pulls from containership cloud and syncs a clusters autoscaling policies resources.

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?
* Addresses https://github.com/containership/cluster-manager/issues/16

 #### Additional Considerations

 ### Testing

I created an image and ran it on a test cluster. Then checked to see if the asp's where created and checked the logs. 

```
$ kubectl get asp
NAME                                   AGE
34e690be-fc04-4958-8348-fcecaf4598ac   11h
a203c340-3ff2-4ab4-b348-6d5b4ff80e23   11h
```

 #### Setup

 #### Instructions

 ### Dependencies
* containership/example#2