### PR TITLE
Update Cerebral to make ScalingStrategy optional

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,7 +58,7 @@
   version = "v1.15.79"
 
 [[projects]]
-  digest = "1:6f7d4c3456f1450d1cff4463c65c727a6626706d8302e353395c5b34e1477ff3"
+  digest = "1:bf59ddcfb1940ca8d41c45213b18b9b6e68e0ec6b0460ada523394223c5b8828"
   name = "github.com/containership/cerebral"
   packages = [
     "pkg/apis/cerebral.containership.io",
@@ -75,7 +75,7 @@
     "pkg/client/listers/cerebral.containership.io/v1alpha1",
   ]
   pruneopts = "T"
-  revision = "6f6c2688ddab9d681c06e81e65d8c06e01a31cde"
+  revision = "845355abee26fb665cb1163d0faf5ed54f8fa085"
 
 [[projects]]
   digest = "1:9f42202ac457c462ad8bb9642806d275af9ab4850cf0b1960b9c6f083d4a309a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@ required = [
 
 [[constraint]]
   name = "github.com/containership/cerebral"
-  revision = "6f6c2688ddab9d681c06e81e65d8c06e01a31cde"
+  revision = "845355abee26fb665cb1163d0faf5ed54f8fa085"
 
 [prune]
   go-tests = true

--- a/pkg/resources/autoscaling_group_test.go
+++ b/pkg/resources/autoscaling_group_test.go
@@ -31,6 +31,116 @@ var autoscalingGroupBytesDisabled = []byte(`[{
 	}
 }]`)
 
+type strategiesEqualTest struct {
+	s1 *cerebralv1alpha1.ScalingStrategy
+	s2 *cerebralv1alpha1.ScalingStrategy
+
+	expected bool
+	message  string
+}
+
+var strategiesEqualTests = []strategiesEqualTest{
+	{
+		s1:       nil,
+		s2:       nil,
+		expected: true,
+		message:  "nil strategy == nil strategy",
+	},
+	{
+		s1:       &cerebralv1alpha1.ScalingStrategy{},
+		s2:       nil,
+		expected: false,
+		message:  "empty strategy != nil strategy",
+	},
+	{
+		s1:       nil,
+		s2:       &cerebralv1alpha1.ScalingStrategy{},
+		expected: false,
+		message:  "nil strategy != empty strategy",
+	},
+	{
+		s1:       &cerebralv1alpha1.ScalingStrategy{},
+		s2:       &cerebralv1alpha1.ScalingStrategy{},
+		expected: true,
+		message:  "empty strategy == empty strategy",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp: "up-strategy",
+		},
+		s2:       &cerebralv1alpha1.ScalingStrategy{},
+		expected: false,
+		message:  "non-empty scale up strategy only != empty scale up strategy",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleDown: "up-strategy",
+		},
+		s2:       &cerebralv1alpha1.ScalingStrategy{},
+		expected: false,
+		message:  "non-empty scale up strategy only != empty scale up strategy",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp: "up-strategy",
+		},
+		s2: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp: "up-strategy",
+		},
+		expected: true,
+		message:  "scale up strategy only == scale up strategy only",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp: "up-strategy",
+		},
+		s2: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp: "different-up-strategy",
+		},
+		expected: false,
+		message:  "scale up strategy only != different scale up strategy only",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleDown: "down-strategy",
+		},
+		s2: &cerebralv1alpha1.ScalingStrategy{
+			ScaleDown: "down-strategy",
+		},
+		expected: true,
+		message:  "scale down strategy only == scale down strategy only",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleDown: "down-strategy",
+		},
+		s2: &cerebralv1alpha1.ScalingStrategy{
+			ScaleDown: "different-down-strategy",
+		},
+		expected: false,
+		message:  "scale down strategy only != different scale down strategy only",
+	},
+	{
+		s1: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp:   "up-strategy",
+			ScaleDown: "down-strategy",
+		},
+		s2: &cerebralv1alpha1.ScalingStrategy{
+			ScaleUp:   "up-strategy",
+			ScaleDown: "down-strategy",
+		},
+		expected: true,
+		message:  "scale strategies the same",
+	},
+}
+
+func TestScalingStrategiesAreEqual(t *testing.T) {
+	for _, test := range strategiesEqualTests {
+		equal := scalingStrategiesAreEqual(test.s1, test.s2)
+		assert.Equal(t, test.expected, equal, test.message)
+	}
+}
+
 func TestPoliciesAreEqual(t *testing.T) {
 	policies1 := []string{"policy-1", "policy-2", "policy-3"}
 	policies2 := []string{"policy-1", "policy-2"}
@@ -98,7 +208,7 @@ var cerebralAutoscalingGroup = cerebralv1alpha1.AutoscalingGroup{
 		Suspended:      true,
 		MinNodes:       1,
 		MaxNodes:       3,
-		ScalingStrategy: cerebralv1alpha1.ScalingStrategy{
+		ScalingStrategy: &cerebralv1alpha1.ScalingStrategy{
 			ScaleUp:   "random",
 			ScaleDown: "leastPods",
 		},


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

 Update Cerebral to make ScalingStrategy optional

 #### What issue(s) does this fix?
* None, but related to https://github.com/containership/cerebral/pull/35

 #### Additional Considerations

 ### Testing

 - Provision cluster on DO
- Change `coordinator` image to be one built from this branch
- Enable autoscaling on worker pool and see ASG properly synced down

 ### Dependencies
* None