### PR TITLE
Update compatibility matrix for version 5.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Please also refer to the [official changelog][cluster-management-changelog] for 
 
 ### Compatibility Matrix
 
-Note that only currently supported versions in the sliding window are listed here for conciseness.
 Support for previous Kubernetes versions can be inferred by using the sliding window.
 For example, `cluster-manager` 2.x supports Kubernetes versions 1.8.x - 1.10.x.
 
-|                     | Kubernetes 1.12.x | Kubernetes 1.11.x | Kubernetes 1.10.x |
-|---------------------|-------------------|-------------------|-------------------|
-| cluster-manager 4.x | ✓                 | ✓                 | ✓                 |
-| cluster-manager 3.x | ✗                 | ✓                 | ✓                 |
-| cluster-manager 2.x | ✗                 | ✗                 | ✓                 |
+|                     | Kubernetes 1.13.x | Kubernetes 1.12.x | Kubernetes 1.11.x | Kubernetes 1.10.x |
+|---------------------|-------------------|-------------------|-------------------|-------------------|
+| cluster-manager 5.x | ✓                 | ✓                 | ✓                 | ✗                 |
+| cluster-manager 4.x | ✗                 | ✓                 | ✓                 | ✓                 |
+| cluster-manager 3.x | ✗                 | ✗                 | ✓                 | ✓                 |
+| cluster-manager 2.x | ✗                 | ✗                 | ✗                 | ✓                 |
 
 
 ## Contributing


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Adds cluster manager version 5.x.x and Kubernetes version 1.13.x to compatibilty matrix.

 #### What issue(s) does this fix?
N/A

 #### Additional Considerations
N/A

 ### Testing

 #### Setup
N/A

 #### Instructions
N/A

 ### Dependencies
N/A
