### PR TITLE
remove glog package from lock remove logstderr flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -249,14 +249,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
   digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
@@ -949,12 +941,12 @@
   revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
 
 [[projects]]
-  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
+  digest = "1:72fd56341405f53c745377e0ebc4abeff87f1a048e0eea6568a20212650f5a82"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
+  revision = "71442cd4037d612096940ceb0f3fec3f7fff66e0"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
@@ -991,7 +983,6 @@
     "github.com/davecgh/go-spew/spew",
     "github.com/dgrijalva/jwt-go",
     "github.com/fsnotify/fsnotify",
-    "github.com/golang/glog",
     "github.com/gorilla/mux",
     "github.com/pkg/errors",
     "github.com/spf13/afero",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,6 +71,10 @@ required = [
   name = "k8s.io/code-generator"
   version = "kubernetes-1.13.3"
 
+[[override]]
+  name = "k8s.io/klog"
+  version = "v0.2.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/cloud_agent/agent.go
+++ b/cmd/cloud_agent/agent.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"runtime"
 
 	"github.com/containership/cluster-manager/pkg/agent"
@@ -14,12 +13,6 @@ func main() {
 	log.Info("Starting Containership Cloud Agent...")
 	log.Infof("Version: %s", buildinfo.String())
 	log.Infof("Go Version: %s", runtime.Version())
-
-	// We don't have any of our own flags to parse, but k8s packages want to
-	// use glog and we have to pass flags to that to configure it to behave
-	// in a sane way.
-	flag.Set("logtostderr", "true")
-	flag.Parse()
 
 	env.Dump()
 

--- a/cmd/cloud_coordinator/coordinator.go
+++ b/cmd/cloud_coordinator/coordinator.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"runtime"
 
 	"github.com/containership/cluster-manager/pkg/buildinfo"
@@ -15,12 +14,6 @@ func main() {
 	log.Info("Starting Containership Cloud Coordinator...")
 	log.Infof("Version: %s", buildinfo.String())
 	log.Infof("Go Version: %s", runtime.Version())
-
-	// We don't have any of our own flags to parse, but k8s packages want to
-	// use glog and we have to pass flags to that to configure it to behave
-	// in a sane way.
-	flag.Set("logtostderr", "true")
-	flag.Parse()
 
 	env.Dump()
 


### PR DESCRIPTION
 ### Description

Fixes Gopkg.lock file, and removes `logtostderr` for agent and coordinator. This flag defaulted to true in the klog package. 

 #### What does this pull request accomplish?

 #### What issue(s) does this fix?
* Fixes #42 

 #### Additional Considerations

 ### Testing

Created 1.12.5 cluster using these changes in docker image `ashleyschuett/cloud-agent:latest` and `ashleyschuett/cloud-coordinator:latest`

Upgraded cluster to 1.13.3

Checked coordinator and agent pods after successfully upgrading an HA cluster,  all where running and did not have log file error. 

^^ I did this test on 3 separate HA clusters. However more testing still. needs to be done per the comment on PR #43  

```
$ kubectl -n containership-core get pods
NAME                                         READY   STATUS              RESTARTS   AGE
cerebral-79999c6c67-mkdsz                    1/1     Running             1          8m11s
cloud-agent-7lbx4                            1/1     Running             1          9m30s
cloud-agent-cf8jk                            1/1     Running             1          9m30s
cloud-agent-lp8qx                            1/1     Running             1          9m30s
cloud-agent-mnhs4                            1/1     Running             2          9m30s
cloud-coordinator-69fc48ff66-7nw9l           1/1     Running             2          9m30s
```

 #### Setup

 #### Instructions

 ### Dependencies