### PR TITLE
Force logstderr to true and init klog flags before setting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -249,14 +249,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
-  branch = "master"
   digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
@@ -949,12 +941,12 @@
   revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
 
 [[projects]]
-  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
+  digest = "1:72fd56341405f53c745377e0ebc4abeff87f1a048e0eea6568a20212650f5a82"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
+  revision = "71442cd4037d612096940ceb0f3fec3f7fff66e0"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
@@ -991,7 +983,6 @@
     "github.com/davecgh/go-spew/spew",
     "github.com/dgrijalva/jwt-go",
     "github.com/fsnotify/fsnotify",
-    "github.com/golang/glog",
     "github.com/gorilla/mux",
     "github.com/pkg/errors",
     "github.com/spf13/afero",
@@ -1039,6 +1030,7 @@
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
     "k8s.io/gengo/args",
+    "k8s.io/klog",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,6 +71,10 @@ required = [
   name = "k8s.io/code-generator"
   version = "kubernetes-1.13.3"
 
+[[constraint]]
+  name = "k8s.io/klog"
+  version = "0.2.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/cmd/cloud_agent/agent.go
+++ b/cmd/cloud_agent/agent.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"runtime"
 
+	"k8s.io/klog"
+
 	"github.com/containership/cluster-manager/pkg/agent"
 	"github.com/containership/cluster-manager/pkg/buildinfo"
 	"github.com/containership/cluster-manager/pkg/env"
@@ -16,8 +18,9 @@ func main() {
 	log.Infof("Go Version: %s", runtime.Version())
 
 	// We don't have any of our own flags to parse, but k8s packages want to
-	// use glog and we have to pass flags to that to configure it to behave
+	// use klog and we have to pass flags to that to configure it to behave
 	// in a sane way.
+	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
@@ -27,6 +30,6 @@ func main() {
 	go agent.Run()
 
 	// Note that we'll never actually exit because some goroutines out of our
-	// control (e.g. the glog flush daemon) will continue to run).
+	// control (e.g. the klog flush daemon) will continue to run).
 	runtime.Goexit()
 }

--- a/cmd/cloud_coordinator/coordinator.go
+++ b/cmd/cloud_coordinator/coordinator.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"runtime"
 
+	"k8s.io/klog"
+
 	"github.com/containership/cluster-manager/pkg/buildinfo"
 	"github.com/containership/cluster-manager/pkg/coordinator"
 	"github.com/containership/cluster-manager/pkg/env"
@@ -17,8 +19,9 @@ func main() {
 	log.Infof("Go Version: %s", runtime.Version())
 
 	// We don't have any of our own flags to parse, but k8s packages want to
-	// use glog and we have to pass flags to that to configure it to behave
+	// use klog and we have to pass flags to that to configure it to behave
 	// in a sane way.
+	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?

In the same vein as https://github.com/containership/cluster-manager/pull/44. Forces the `logtostderr` flag to true

 #### What issue(s) does this fix?
* Fixes https://github.com/containership/cluster-manager/issues/42

 #### Additional Considerations

It is crashing because we have our agent and coordinator in scratch containers with the only binary being the actual agent itself.

 ### Testing

* Injected a `klog.Error` statement into the main function. 
  * With `flag.Set('logtostderr', 'false')` the agents crashed immediately on startup. 
  * With `flag.Set('logtostderr', 'true')` the agents worked as expected and logged to stderr.
 