### PR TITLE
Support multiple pending ClusterUpgrades

### DIFF
--- a/pkg/coordinator/node_cloud_status.go
+++ b/pkg/coordinator/node_cloud_status.go
@@ -30,11 +30,11 @@ const (
 	NodeCloudStatusRunning = "RUNNING"
 )
 
-// PostNodeCloudStatusMessage posts the node cloud status to cloud. Note that this
+// postNodeCloudStatusMessage posts the node cloud status to cloud. Note that this
 // status is not (currently) intended to be strictly identical to the actual
 // node status in the ClusterUpgrade CRD and is only used for essentially a
 // boolean "is running or not" check on cloud side.
-func PostNodeCloudStatusMessage(nodeID string, status *NodeCloudStatusMessage) error {
+func postNodeCloudStatusMessage(nodeID string, status *NodeCloudStatusMessage) error {
 	path := fmt.Sprintf("/organizations/{{.OrganizationID}}/clusters/{{.ClusterID}}/nodes/%s/status", nodeID)
 
 	body, err := json.Marshal(status)
@@ -56,15 +56,15 @@ func PostNodeCloudStatusMessage(nodeID string, status *NodeCloudStatusMessage) e
 	return nil
 }
 
-// PostNodeCloudStatusMessageWithRetry posts the node cloud status, retrying up to
+// postNodeCloudStatusMessageWithRetry posts the node cloud status, retrying up to
 // numRetries times.
 // TODO consider using a library such as `pester` to handle actual HTTP retries
 // here and elsewhere
-func PostNodeCloudStatusMessageWithRetry(nodeID string, status *NodeCloudStatusMessage, numRetries int) error {
+func postNodeCloudStatusMessageWithRetry(nodeID string, status *NodeCloudStatusMessage, numRetries int) error {
 	var err error
 	for attempt := 1; attempt <= numRetries; attempt++ {
 		log.Debugf("PUT node cloud status attempt %d", attempt)
-		if err = PostNodeCloudStatusMessage(nodeID, status); err == nil {
+		if err = postNodeCloudStatusMessage(nodeID, status); err == nil {
 			// Request was successful so we're done
 			break
 		}

--- a/pkg/coordinator/upgrade_controller.go
+++ b/pkg/coordinator/upgrade_controller.go
@@ -459,7 +459,7 @@ func tryPostNodeCloudStatusRunning(nodeID string) {
 			Percent: "1",
 		},
 	}
-	_ = PostNodeCloudStatusMessageWithRetry(nodeID, &status, 3)
+	_ = postNodeCloudStatusMessageWithRetry(nodeID, &status, 3)
 }
 
 // updateClusterUpgradeStatus posts an updated status for the given upgrade object

--- a/pkg/coordinator/upgrade_controller.go
+++ b/pkg/coordinator/upgrade_controller.go
@@ -201,13 +201,10 @@ func (uc *UpgradeController) processNextWorkItem() bool {
 		case "node":
 			err := uc.nodeSyncHandler(key)
 			return uc.handleErr(err, key)
+		default:
+			// Do not use handleErr, as we do not want to re-enqueue in this case
+			return errors.Errorf("unknown kind %s in queue for %s", kind, upgradeControllerName)
 		}
-
-		// Finally, if no error occurs we forget this item so it does not
-		// get queued again until another change happens.
-		uc.workqueue.Forget(obj)
-		log.Debugf("%s: Successfully synced '%s'", upgradeControllerName, key)
-		return nil
 	}(obj)
 
 	if err != nil {

--- a/pkg/coordinator/upgrade_controller_test.go
+++ b/pkg/coordinator/upgrade_controller_test.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -19,73 +20,15 @@ import (
 	csclientset "github.com/containership/cluster-manager/pkg/client/clientset/versioned"
 	fakecsv3 "github.com/containership/cluster-manager/pkg/client/clientset/versioned/fake"
 	csinformers "github.com/containership/cluster-manager/pkg/client/informers/externalversions"
+	csinformersprovisionv3 "github.com/containership/cluster-manager/pkg/client/informers/externalversions/provision.containership.io/v3"
 	"github.com/containership/cluster-manager/pkg/env"
 )
 
-type buildLabelTest struct {
-	name     string
-	cluster  []runtime.Object
-	input    *provisioncsv3.ClusterUpgrade
-	expected runtime.Object
-}
-
-var masterNodeTrue = &v1.Node{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "master-true",
-		Labels: map[string]string{
-			"containership.io/managed":       "true",
-			"node-role.kubernetes.io/master": "",
-		},
-	},
-}
-
-var masterNodeUnmanaged = &v1.Node{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "master-true-unmanaged",
-		Labels: map[string]string{
-			"node-role.kubernetes.io/master": "",
-		},
-	},
-}
-
-var workerNode = &v1.Node{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "worker-master-flag-dne",
-		Labels: map[string]string{
-			"containership.io/managed": "true",
-		},
-	},
-}
-
-var masterNodeWithVersion = &v1.Node{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "master-with-version",
-		Labels: map[string]string{
-			"containership.io/managed":       "true",
-			"node-role.kubernetes.io/master": "",
-		},
-	},
-	Status: v1.NodeStatus{
-		NodeInfo: v1.NodeSystemInfo{
-			KubeletVersion: "v1.9.2",
-		},
-	},
-}
-
-var masterNodeWithLabel = &v1.Node{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "master-with-label",
-		Labels: map[string]string{
-			"containership.io/managed":       "true",
-			"node-role.kubernetes.io/master": "",
-			"custom.label/key":               "value",
-		},
-	},
-}
-
-const APIServer = "kube-apiserver"
-const ControllerManager = "kube-controller-manager"
-const Scheduler = "kube-scheduler"
+const (
+	APIServer         = "kube-apiserver"
+	ControllerManager = "kube-controller-manager"
+	Scheduler         = "kube-scheduler"
+)
 
 var controlPlane = []*v1.Pod{
 	{
@@ -141,86 +84,165 @@ var controlPlane = []*v1.Pod{
 	},
 }
 
-var tests = []buildLabelTest{
-	{
-		name: "Master node next",
-		input: &provisioncsv3.ClusterUpgrade{
-			Spec: provisioncsv3.ClusterUpgradeSpec{
-				Type:          provisioncsv3.UpgradeTypeKubernetes,
-				TargetVersion: "v1.9.2",
+func TestGetNextNode(t *testing.T) {
+	masterNodeTrue := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-true",
+			Labels: map[string]string{
+				"containership.io/managed":       "true",
+				"node-role.kubernetes.io/master": "",
 			},
 		},
-		cluster: []runtime.Object{
-			masterNodeTrue,
-			workerNode,
-		},
-		expected: masterNodeTrue,
-	},
-	{
-		name: "Master node unmanaged",
-		input: &provisioncsv3.ClusterUpgrade{
-			Spec: provisioncsv3.ClusterUpgradeSpec{
-				Type:          provisioncsv3.UpgradeTypeKubernetes,
-				TargetVersion: "v1.9.2",
+	}
+
+	masterNodeUnmanaged := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-true-unmanaged",
+			Labels: map[string]string{
+				"node-role.kubernetes.io/master": "",
 			},
 		},
-		cluster: []runtime.Object{
-			masterNodeUnmanaged,
-			workerNode,
-		},
-		expected: workerNode,
-	},
-	{
-		name: "Master node at desired version. return worker",
-		input: &provisioncsv3.ClusterUpgrade{
-			Spec: provisioncsv3.ClusterUpgradeSpec{
-				Type:          provisioncsv3.UpgradeTypeKubernetes,
-				TargetVersion: "v1.9.2",
+	}
+
+	workerNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-master-flag-dne",
+			Labels: map[string]string{
+				"containership.io/managed": "true",
 			},
 		},
-		cluster: []runtime.Object{
-			masterNodeWithVersion,
-			workerNode,
-		},
-		expected: workerNode,
-	},
-	{
-		name: "Master node at desired version. return next master",
-		input: &provisioncsv3.ClusterUpgrade{
-			Spec: provisioncsv3.ClusterUpgradeSpec{
-				Type:          provisioncsv3.UpgradeTypeKubernetes,
-				TargetVersion: "v1.9.2",
+	}
+
+	masterNodeWithVersion := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-with-version",
+			Labels: map[string]string{
+				"containership.io/managed":       "true",
+				"node-role.kubernetes.io/master": "",
 			},
 		},
-		cluster: []runtime.Object{
-			masterNodeWithVersion,
-			masterNodeTrue,
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				KubeletVersion: "v1.9.2",
+			},
 		},
-		expected: masterNodeTrue,
-	},
-	{
-		name: "Get node with label selector",
-		input: &provisioncsv3.ClusterUpgrade{
-			Spec: provisioncsv3.ClusterUpgradeSpec{
-				TargetVersion: "v1.9.2",
-				LabelSelector: []provisioncsv3.LabelSelectorSpec{
-					{
-						Label:    "custom.label/key",
-						Operator: "=",
-						Value:    []string{"value"},
+	}
+
+	masterNodeWithVersionCopy := masterNodeWithVersion.DeepCopy()
+	// Must mutate name in order to place in cache without overwriting
+	masterNodeWithVersionCopy.Name = "master-with-version-copy"
+
+	masterNodeWithLabel := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-with-label",
+			Labels: map[string]string{
+				"containership.io/managed":       "true",
+				"node-role.kubernetes.io/master": "",
+				"custom.label/key":               "value",
+			},
+		},
+	}
+
+	type getNextNodeTest struct {
+		name     string
+		cluster  []runtime.Object
+		input    *provisioncsv3.ClusterUpgrade
+		expected runtime.Object
+	}
+
+	var nilNode *v1.Node
+	tests := []getNextNodeTest{
+		{
+			name: "Master node next",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					Type:          provisioncsv3.UpgradeTypeKubernetes,
+					TargetVersion: "v1.9.2",
+				},
+			},
+			cluster: []runtime.Object{
+				masterNodeTrue,
+				workerNode,
+			},
+			expected: masterNodeTrue,
+		},
+		{
+			name: "Master node unmanaged",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					Type:          provisioncsv3.UpgradeTypeKubernetes,
+					TargetVersion: "v1.9.2",
+				},
+			},
+			cluster: []runtime.Object{
+				masterNodeUnmanaged,
+				workerNode,
+			},
+			expected: workerNode,
+		},
+		{
+			name: "Master node at desired version. return worker",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					Type:          provisioncsv3.UpgradeTypeKubernetes,
+					TargetVersion: "v1.9.2",
+				},
+			},
+			cluster: []runtime.Object{
+				masterNodeWithVersion,
+				workerNode,
+			},
+			expected: workerNode,
+		},
+		{
+			name: "Master node at desired version. return next master",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					Type:          provisioncsv3.UpgradeTypeKubernetes,
+					TargetVersion: "v1.9.2",
+				},
+			},
+			cluster: []runtime.Object{
+				masterNodeWithVersion,
+				masterNodeTrue,
+			},
+			expected: masterNodeTrue,
+		},
+		{
+			name: "All nodes at desired version",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					Type:          provisioncsv3.UpgradeTypeKubernetes,
+					TargetVersion: "v1.9.2",
+				},
+			},
+			cluster: []runtime.Object{
+				masterNodeWithVersion,
+			},
+			expected: nilNode,
+		},
+		{
+			name: "Get node with label selector",
+			input: &provisioncsv3.ClusterUpgrade{
+				Spec: provisioncsv3.ClusterUpgradeSpec{
+					TargetVersion: "v1.9.2",
+					LabelSelector: []provisioncsv3.LabelSelectorSpec{
+						{
+							Label:    "custom.label/key",
+							Operator: "=",
+							Value:    []string{"value"},
+						},
 					},
 				},
 			},
+			cluster: []runtime.Object{
+				masterNodeWithLabel,
+				masterNodeTrue,
+			},
+			expected: masterNodeWithLabel,
 		},
-		cluster: []runtime.Object{
-			masterNodeWithLabel,
-			masterNodeTrue,
-		},
-		expected: masterNodeWithLabel,
-	},
-}
+	}
 
-func TestGetNextNode(t *testing.T) {
 	for _, test := range tests {
 		client, kubeInformerFactory := initializeFakeKubeclient()
 		csclientset, csInformerFactory := initializeFakeContainershipClient()
@@ -228,11 +250,138 @@ func TestGetNextNode(t *testing.T) {
 			client, csclientset, kubeInformerFactory, csInformerFactory)
 
 		nodeInformer := kubeInformerFactory.Core().V1().Nodes()
-		initializeStore(nodeInformer, test.cluster)
+		initializeNodeStore(nodeInformer, test.cluster)
 		initializeFakeControlPlane(kubeInformerFactory, test.cluster)
 
 		result := cupController.getNextNode(test.input)
 		assert.Equal(t, test.expected, result, test.name)
+	}
+}
+
+func TestGetNextUpgrade(t *testing.T) {
+	upgradeSuccess := &provisioncsv3.ClusterUpgrade{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-success",
+			Namespace: "containership-core",
+			Labels: map[string]string{
+				"containership.io/managed": "true",
+			},
+			CreationTimestamp: metav1.NewTime(time.Unix(0, 0)),
+		},
+		Spec: provisioncsv3.ClusterUpgradeSpec{
+			Type:          provisioncsv3.UpgradeTypeKubernetes,
+			TargetVersion: "v1.14.1",
+			Status: provisioncsv3.ClusterUpgradeStatusSpec{
+				ClusterStatus: provisioncsv3.UpgradeSuccess,
+			},
+		},
+	}
+
+	upgradeFailed := upgradeSuccess.DeepCopy()
+	upgradeFailed.Name = "upgrade-failed"
+	upgradeFailed.Spec.Status = provisioncsv3.ClusterUpgradeStatusSpec{
+		ClusterStatus: provisioncsv3.UpgradeSuccess,
+	}
+
+	// Pending upgrades don't have a status set
+	upgradePendingTime0 := &provisioncsv3.ClusterUpgrade{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-pending-time-0",
+			Namespace: "containership-core",
+			Labels: map[string]string{
+				"containership.io/managed": "true",
+			},
+			CreationTimestamp: metav1.NewTime(time.Unix(0, 0)),
+		},
+		Spec: provisioncsv3.ClusterUpgradeSpec{
+			Type:          provisioncsv3.UpgradeTypeKubernetes,
+			TargetVersion: "v1.14.1",
+		},
+	}
+
+	upgradePendingTime20 := upgradePendingTime0.DeepCopy()
+	upgradePendingTime20.Name = "upgrade-pending-time-20"
+	upgradePendingTime20.CreationTimestamp = metav1.NewTime(time.Unix(20, 0))
+
+	upgradePendingTime100 := upgradePendingTime0.DeepCopy()
+	upgradePendingTime20.Name = "upgrade-pending-time-100"
+	upgradePendingTime100.CreationTimestamp = metav1.NewTime(time.Unix(100, 0))
+
+	type getNextUpgradeTest struct {
+		name     string
+		upgrades []runtime.Object
+
+		expected    runtime.Object
+		shouldError bool
+	}
+
+	// TODO test error cases
+	// Need this for typed nil
+	var nilUpgrade *provisioncsv3.ClusterUpgrade
+	tests := []getNextUpgradeTest{
+		{
+			name:        "No upgrades",
+			upgrades:    []runtime.Object{},
+			expected:    nilUpgrade,
+			shouldError: false,
+		},
+		{
+			name: "No pending upgrades",
+			upgrades: []runtime.Object{
+				upgradeSuccess,
+				upgradeFailed,
+			},
+			expected:    nilUpgrade,
+			shouldError: false,
+		},
+		{
+			name: "Only one pending upgrade",
+			upgrades: []runtime.Object{
+				upgradePendingTime0,
+			},
+			expected:    upgradePendingTime0,
+			shouldError: false,
+		},
+		{
+			name: "One pending upgrade and multiple finished",
+			upgrades: []runtime.Object{
+				upgradeSuccess,
+				upgradePendingTime0,
+				upgradeFailed,
+			},
+			expected:    upgradePendingTime0,
+			shouldError: false,
+		},
+		{
+			name: "Multiple pending upgrades",
+			upgrades: []runtime.Object{
+				upgradeSuccess,
+				upgradePendingTime100,
+				upgradeFailed,
+				upgradePendingTime0,
+				upgradePendingTime20,
+			},
+			expected:    upgradePendingTime0,
+			shouldError: false,
+		},
+	}
+
+	for _, test := range tests {
+		client, kubeInformerFactory := initializeFakeKubeclient()
+		csclientset, csInformerFactory := initializeFakeContainershipClient()
+		cupController := NewUpgradeController(
+			client, csclientset, kubeInformerFactory, csInformerFactory)
+
+		upgradeInformer := csInformerFactory.ContainershipProvision().V3().ClusterUpgrades()
+		initializeClusterUpgradeStore(upgradeInformer, test.upgrades)
+
+		result, err := cupController.getNextUpgrade()
+		if test.shouldError {
+			assert.Error(t, err, result, test.name)
+		} else {
+			assert.NoError(t, err, result, test.name)
+			assert.Equal(t, test.expected, result, test.name)
+		}
 	}
 }
 
@@ -254,7 +403,14 @@ func initializeFakeContainershipClient() (csclientset.Interface, csinformers.Sha
 	return csclientset, csInformerFactory
 }
 
-func initializeStore(informer kubeinformerscorev1.NodeInformer, objs []runtime.Object) {
+func initializeNodeStore(informer kubeinformerscorev1.NodeInformer, objs []runtime.Object) {
+	for _, obj := range objs {
+		err := informer.Informer().GetStore().Add(obj)
+		fmt.Println(err)
+	}
+}
+
+func initializeClusterUpgradeStore(informer csinformersprovisionv3.ClusterUpgradeInformer, objs []runtime.Object) {
 	for _, obj := range objs {
 		err := informer.Informer().GetStore().Add(obj)
 		fmt.Println(err)


### PR DESCRIPTION
### Description

 #### What does this pull request accomplish?

Support multiple pending ClusterUpgrades

 #### What issue(s) does this fix?
* Fixes #58

 #### Additional Considerations

 ### Testing

- Provision a 1.12.6 cluster on DigitalOcean
- Add a bunch of new master pools using csctl
- Queue up upgrades for all master pools at once using csctl
- See all upgrades succeed

 ### Dependencies
None