### PR TITLE
fix directory reference for plugin delete

### DIFF
--- a/pkg/coordinator/plugin_controller.go
+++ b/pkg/coordinator/plugin_controller.go
@@ -319,7 +319,7 @@ func (c *PluginController) deletePlugin(name string) error {
 	fileManager := pluginFileManager{
 		name,
 	}
-	pluginPath := fileManager.pluginDir()
+	pluginPath := fileManager.pluginManifestsDir()
 
 	var kc *kubectl.Kubectl
 	if stat, err := os.Stat(pluginPath); os.IsNotExist(err) || !stat.IsDir() {


### PR DESCRIPTION
 ### Description

The code was referencing a child directory for deleting plugins, which made deleting a plugin error and never actually be deleted. 

 #### What does this pull request accomplish?

This now checks for `/plugins/uuid/manifests` directory to exist and then deletes the plugin based on the manifests in that directory. 

 #### What issue(s) does this fix?

 #### Additional Considerations

 ### Testing
- created a cluster running a version of coordinator with this change
- deleted a plugin
- plugin deployment was removed from the cluster 

 #### Setup

 #### Instructions

 ### Dependencies
