### PR TITLE
Correctly set Kind of the owner reference

### DIFF
--- a/pkg/coordinator/authorization_role_binding_controller.go
+++ b/pkg/coordinator/authorization_role_binding_controller.go
@@ -324,7 +324,7 @@ func ownerReferenceForAuthorizationRoleBinding(binding csauthv3.AuthorizationRol
 	return metav1.OwnerReference{
 		// Can't use binding TypeMeta because it's not guaranteed to be filled in
 		APIVersion: csauthv3.SchemeGroupVersion.String(),
-		Kind:       "AuthorizationRole",
+		Kind:       "AuthorizationRoleBinding",
 		Name:       binding.Name,
 		UID:        binding.UID,
 	}


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
Fixes invalid owner references of `ClusterRoleBinding` causing garbage collection to immediately delete

 #### What issue(s) does this fix?
* Fixes https://github.com/containership/cluster-manager/issues/85

 #### Additional Considerations
* See discussion at https://github.com/containership/cluster-manager/issues/85. I'm not sure how / why this exactly works still even though this definitely was a blatant issue. 
* Also unsure of why / how it has not manifested until now

 ### Testing
Difficult, to initiate, but once it starts garbage collecting, then it repeatedly deleted existing `ClusterRoleBindings` because none of them have a valid owner reference

> Maybe there is some sort of grace period before garbage collection initiates?