### PR TITLE
Fix coordinate lookup file provider index keys for aws and gce

### DIFF
--- a/pkg/geohash/coordinates_lookup.go
+++ b/pkg/geohash/coordinates_lookup.go
@@ -10,7 +10,7 @@ type coordinates struct {
 }
 
 var coordinatesLookup = map[string]map[string]coordinates{
-	"amazon_web_services": {
+	"aws": {
 		"ap-south-1": coordinates{
 			lat: 19.076,
 			lon: 72.8777,
@@ -272,7 +272,7 @@ var coordinatesLookup = map[string]map[string]coordinates{
 			lon: -79.3832,
 		},
 	},
-	"google": {
+	"gce": {
 		"asia-east1": coordinates{
 			lat: 24.0518,
 			lon: 120.5161,

--- a/pkg/geohash/geohash_test.go
+++ b/pkg/geohash/geohash_test.go
@@ -30,15 +30,39 @@ func TestForProviderAndRegion(t *testing.T) {
 		},
 		{
 			provider:    "amazon_web_services",
-			region:      "bad",
+			region:      "us-east-1",
 			shouldError: true,
-			message:     "nonexistent provider",
+			message:     "nonexistent provider due to errant spelling of aws provider",
 		},
 		{
-			provider: "amazon_web_services",
+			provider:    "aws",
+			region:      "bad",
+			shouldError: true,
+			message:     "nonexistent region for aws",
+		},
+		{
+			provider: "aws",
 			region:   "us-east-1",
 			expected: "dqbyhexqseyg",
-			message:  "good entry",
+			message:  "good entry for aws",
+		},
+		{
+			provider:    "google",
+			region:      "europe-west2",
+			shouldError: true,
+			message:     "nonexistent provider due to errant spelling of gce provider",
+		},
+		{
+			provider:    "gce",
+			region:      "bad",
+			shouldError: true,
+			message:     "nonexistent region for gce",
+		},
+		{
+			provider: "gce",
+			region:   "europe-west2",
+			expected: "gcpvj0duq533",
+			message:  "good entry for gce",
 		},
 	}
 


### PR DESCRIPTION
 ### Description

 #### What does this pull request accomplish?
* Fixes providerID keys in the coordinate lookup file
* Added test cases to cover as well as enhanced message description for tests

 #### What issue(s) does this fix?
* Fixes https://github.com/containership/cluster-manager/issues/98

 #### Additional Considerations
n/a

 ### Testing
Checked providerID on google and aws nodes

 #### Setup
n/a

 #### Instructions
n/a

 ### Dependencies
n/a
